### PR TITLE
make script behave more as expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 iPhone6,1_7.1.2_11D257_Restore.ipsw
 iPhone6,1_8.4.1_12H321_Restore.ipsw
+disk0*
 containermanagerd.*
 com.apple.commcenter*
 activation_records


### PR DESCRIPTION
--ramdisk will now use the version u specify when running the command when booting the ramdisk
so instead of `sudo ./semaphorin.sh 9.3.2 --ramdisk` booting a 11.4.1 ramdisk, itll boot a 9.3.2 ramdisk if possible. this goes for other commands as well